### PR TITLE
issue #3: updated according to oclHashcat's revert 586441f

### DIFF
--- a/src/cleanup-rules.c
+++ b/src/cleanup-rules.c
@@ -79,7 +79,7 @@
 #define ATTACK_EXEC_ON_GPU 2
 
 #define MAX_CPU_RULES 255 // this is defined in include/types.h (oclHashcat)
-#define MAX_GPU_RULES 15
+#define MAX_GPU_RULES 14
 
 static int class_num (const char c)
 {


### PR DESCRIPTION
The commit https://github.com/hashcat/oclHashcat/commit/586441fa25a2e2f3113224ae7f26893aebaac45a for oclHashcat reverted the 15 rule function change.