### PR TITLE
add necessary casts to satisfy -Wextra

### DIFF
--- a/src/cleanup-rules.c
+++ b/src/cleanup-rules.c
@@ -95,11 +95,11 @@ static char conv_ctoi (const char c)
 {
   if (class_num (c))
   {
-    return c - '0';
+    return (char)(c - '0');
   }
   else if (class_upper (c))
   {
-    return c - 'A' + 10;
+    return (char)(c - 'A' + 10);
   }
 
   return -1;

--- a/src/cpu_rules.c
+++ b/src/cpu_rules.c
@@ -1173,11 +1173,11 @@ char conv_ctoi (char c)
 {
   if (class_num (c))
   {
-    return c - '0';
+    return (char)(c - '0');
   }
   else if (class_upper (c))
   {
-    return c - 'A' + (char) 10;
+    return (char)(c - 'A' + (char) 10);
   }
 
   return (char) (-1);
@@ -1187,11 +1187,11 @@ char conv_itoc (char c)
 {
   if (c < 10)
   {
-    return c + '0';
+    return (char)(c + (char)'0');
   }
   else if (c < 37)
   {
-    return c + 'A' - (char) 10;
+    return (char)(c + (char)'A' - (char) 10);
   }
 
   return (char) (-1);

--- a/src/hcstatgen.c
+++ b/src/hcstatgen.c
@@ -37,7 +37,7 @@
 
 static uint8_t hex_convert (uint8_t c)
 {
-  return (c & 15) + (c >> 6) * 9;
+  return (uint8_t)((c & 15) + (c >> 6) * 9);
 }
 
 int main (int argc, char *argv[])
@@ -111,18 +111,18 @@ int main (int argc, char *argv[])
 
       for (line_pos = 0; line_pos < line_len - 2; line_pos += 2)
       {
-        uint8_t c0 = hex_convert (line_buf[line_pos + 1]) << 0
-                   | hex_convert (line_buf[line_pos + 0]) << 4;
-        uint8_t c1 = hex_convert (line_buf[line_pos + 3]) << 0
-                   | hex_convert (line_buf[line_pos + 2]) << 4;
+        uint8_t c0 = (uint8_t)(  hex_convert (line_buf[line_pos + 1]) << 0
+                               | hex_convert (line_buf[line_pos + 0]) << 4);
+        uint8_t c1 = (uint8_t)(  hex_convert (line_buf[line_pos + 3]) << 0
+                               | hex_convert (line_buf[line_pos + 2]) << 4);
 
         root_stats_buf_by_pos[line_pos][c0]++;
 
         markov_stats_buf_by_key[line_pos][c0][c1]++;
       }
 
-      uint8_t c0 = hex_convert (line_buf[line_pos + 1]) << 0
-                 | hex_convert (line_buf[line_pos + 0]) << 4;
+      uint8_t c0 = (uint8_t)(  hex_convert (line_buf[line_pos + 1]) << 0
+                             | hex_convert (line_buf[line_pos + 0]) << 4);
 
       root_stats_buf_by_pos[line_pos][c0]++;
     }

--- a/src/keyspace.c
+++ b/src/keyspace.c
@@ -45,7 +45,7 @@ typedef struct
 
 uint8_t hex_convert (const uint8_t c)
 {
-  return (c & 15) + (c >> 6) * 9;
+  return (uint8_t)((c & 15) + (c >> 6) * 9);
 }
 
 void mp_css_to_uniq_tbl (const int css_cnt, cs_t *css_buf, int uniq_tbls[SP_PW_MAX][CHARSIZ])
@@ -155,8 +155,8 @@ void mp_expand (const int in_len, const uint8_t *in_buf, cs_t *mp_sys, cs_t *mp_
 
         const uint8_t p1 = in_buf[in_pos];
 
-        const uint8_t chr = hex_convert (p1) << 0
-                          | hex_convert (p0) << 4;
+        const uint8_t chr = (uint8_t)(  hex_convert (p1) << 0
+                                      | hex_convert (p0) << 4);
 
         mp_add_cs_buf (1, &chr, css_pos, mp_usr);
       }
@@ -227,8 +227,8 @@ cs_t *mp_gen_css (const int in_len, const uint8_t *in_buf, cs_t *mp_sys, cs_t *m
 
         const uint8_t p1 = in_buf[in_pos];
 
-        const uint8_t chr = hex_convert (p1) << 0
-                          | hex_convert (p0) << 4;
+        const uint8_t chr = (uint8_t)(  hex_convert (p1) << 0
+                                      | hex_convert (p0) << 4);
 
         mp_add_cs_buf (1, &chr, css_pos, css_buf);
       }
@@ -256,25 +256,25 @@ void mp_setup_sys (cs_t *mp_sys)
   memset (donec, 0, sizeof (donec));
 
   for (pos = 0, chr =  'a'; chr <=  'z'; chr++) { donec[chr] = 1;
-                                                  mp_sys[0].cs_buf[pos++] = chr;
+                                                  mp_sys[0].cs_buf[pos++] = (uint8_t)chr;
                                                   mp_sys[0].cs_len = pos; }
 
   for (pos = 0, chr =  'A'; chr <=  'Z'; chr++) { donec[chr] = 1;
-                                                  mp_sys[1].cs_buf[pos++] = chr;
+                                                  mp_sys[1].cs_buf[pos++] = (uint8_t)chr;
                                                   mp_sys[1].cs_len = pos; }
 
   for (pos = 0, chr =  '0'; chr <=  '9'; chr++) { donec[chr] = 1;
-                                                  mp_sys[2].cs_buf[pos++] = chr;
+                                                  mp_sys[2].cs_buf[pos++] = (uint8_t)chr;
                                                   mp_sys[2].cs_len = pos; }
 
   for (pos = 0, chr = 0x20; chr <= 0x7e; chr++) { if (donec[chr]) continue;
-                                                  mp_sys[3].cs_buf[pos++] = chr;
+                                                  mp_sys[3].cs_buf[pos++] = (uint8_t)chr;
                                                   mp_sys[3].cs_len = pos; }
 
-  for (pos = 0, chr = 0x20; chr <= 0x7e; chr++) { mp_sys[4].cs_buf[pos++] = chr;
+  for (pos = 0, chr = 0x20; chr <= 0x7e; chr++) { mp_sys[4].cs_buf[pos++] = (uint8_t)chr;
                                                   mp_sys[4].cs_len = pos; }
 
-  for (pos = 0, chr = 0x00; chr <= 0xff; chr++) { mp_sys[5].cs_buf[pos++] = chr;
+  for (pos = 0, chr = 0x00; chr <= 0xff; chr++) { mp_sys[5].cs_buf[pos++] = (uint8_t)chr;
                                                   mp_sys[5].cs_len = pos; }
 }
 
@@ -402,7 +402,7 @@ void sp_setup_tbl (const char *markov_hcstat, hcstat_table_t *root_table_buf, hc
 
   for (i = 0; i < SP_ROOT_CNT; i++)
   {
-    const uint8_t key = i % CHARSIZ;
+    const uint8_t key = (uint8_t)(i % CHARSIZ);
 
     root_table_buf[i].key = key;
     root_table_buf[i].val = root_stats_buf[i];
@@ -410,7 +410,7 @@ void sp_setup_tbl (const char *markov_hcstat, hcstat_table_t *root_table_buf, hc
 
   for (i = 0; i < SP_MARKOV_CNT; i++)
   {
-    const uint8_t key = i % CHARSIZ;
+    const uint8_t key = (uint8_t)(i % CHARSIZ);
 
     markov_table_buf[i].key = key;
     markov_table_buf[i].val = markov_stats_buf[i];

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -67,7 +67,7 @@ int main (int argc, char *argv[])
 
       for (j = 0; j < tmp_buf[tmp_pos]; j++)
       {
-        line_buf[line_pos] = tmp_pos;
+        line_buf[line_pos] = (uint8_t)tmp_pos;
 
         line_pos++;
       }


### PR DESCRIPTION
Several files were assigning values to char and uint8_t types from int types, causing warnings when building with -Wextra.

The offending statements are now cast appropriately.