### PR TITLE
cleanup-rules: fixes #12, allow @X (purge) rule for the rule-engine on GPU

### DIFF
--- a/src/cleanup-rules.c
+++ b/src/cleanup-rules.c
@@ -78,7 +78,7 @@
 #define ATTACK_EXEC_ON_CPU 1
 #define ATTACK_EXEC_ON_GPU 2
 
-#define MAX_CPU_RULES 255 // this is defined in include/types.h (oclHashcat)
+#define MAX_CPU_RULES 255 // this is defined in include/types.h (hashcat)
 #define MAX_GPU_RULES 255
 
 static int class_num (const char c)
@@ -243,7 +243,6 @@ int main (int argc, char *argv[])
 
         case RULE_OP_MANGLE_PURGECHAR:
           NEXT_RULEPOS;
-          DENY_GPU;
           break;
 
         case RULE_OP_MANGLE_TOGGLECASE_REC:

--- a/src/keyspace.c
+++ b/src/keyspace.c
@@ -567,7 +567,7 @@ uint64_t keyspace (const int in_len, const uint8_t *in_buf, cs_t mp_sys[5], cs_t
 void usage (char *program)
 {
   const char *help_text[] = {
-    "%s, keyspace utility for oclHashcat",
+    "%s, keyspace utility for hashcat",
     "",
     "Usage: %s [options] mask",
     "",


### PR DESCRIPTION
Since hashcat recently added support (https://github.com/hashcat/hashcat/commit/8acf5b38797560de0613d77f7eb6d6daee578bcb) for the purge rule (@X) for the GPU-rule-engine, we also need to allow it for the "cleanup-rules" tool of hashcat-utils.

This commit does exactly unblocks the @X rule on GPU (reported by issue #12 which can be closed now).
In addition to that, I found some references to "oclHashcat" that I replaced by just "hashcat".

Thank you very much
