### PR TITLE
cap2hccapx: add additional check for maximum # of bytes that can be copied

### DIFF
--- a/src/cap2hccapx.c
+++ b/src/cap2hccapx.c
@@ -409,6 +409,8 @@ static int handle_auth (const auth_packet_t *auth_packet, const int pkt_offset, 
 
     if ((pkt_offset + excpkt->eapol_len) > pkt_size) return -1;
 
+    if ((sizeof (auth_packet_t) + ap_wpa_key_data_length) > sizeof (excpkt->eapol)) return -1;
+
     // we need to copy the auth_packet_t but have to clear the keymic
     auth_packet_t auth_packet_orig;
 


### PR DESCRIPTION
We should perform this additional bound check to ensure that we never copy more bytes than possible (eapol[256]).

This additional check will eliminate the possibility of a buffer overflow whenever the packets have a length that is too large.

Thanks