### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bin/*.bin
-bin/*.exe
-bin/*.app
-bin/*.pl
+*.bin
+*.exe
+bin/


### PR DESCRIPTION
This updates the gitignore to not track compile outputs (currently generated in the src directory) and to generally exclude the bin folder