### PR TITLE
splitlen: use snprintf () instead of sprintf () to avoid overflows of the buffer

### DIFF
--- a/src/splitlen.c
+++ b/src/splitlen.c
@@ -41,7 +41,7 @@ int main (int argc, char *argv[])
   {
     char name[BUFSIZ];
 
-    sprintf (name, "%s/%02d", argv[1], i);
+    snprintf (name, BUFSIZ, "%s/%02d", argv[1], i);
 
     fps[i] = fopen (name, "wb");
 


### PR DESCRIPTION
This avoids a possible overflow of the file name buffer in splitlen.c

Thank you