### PR TITLE
handle 4addr in IEEE80211 packets properly in cap2hccapx.c

### DIFF
--- a/src/cap2hccapx.c
+++ b/src/cap2hccapx.c
@@ -805,12 +805,8 @@ static void process_packet (const u8 *packet, const pcap_pkthdr_t *header)
   {
     // process header: ieee80211
 
-    int set = 0;
-
-    if (frame_control & IEEE80211_FCTL_TODS)   set++;
-    if (frame_control & IEEE80211_FCTL_FROMDS) set++;
-
-    if (set != 1) return;
+    int addr4_exist = ((frame_control & (IEEE80211_FCTL_TODS | IEEE80211_FCTL_FROMDS)) == 
+    (IEEE80211_FCTL_TODS | IEEE80211_FCTL_FROMDS));
 
     // find offset to llc/snap header
 
@@ -828,6 +824,7 @@ static void process_packet (const u8 *packet, const pcap_pkthdr_t *header)
     // process header: the llc/snap header
 
     if (header->caplen < (llc_offset + sizeof (ieee80211_llc_snap_header_t))) return;
+    if (addr4_exist) llc_offset += 6;
 
     ieee80211_llc_snap_header_t *ieee80211_llc_snap_header = (ieee80211_llc_snap_header_t *) &packet[llc_offset];
 


### PR DESCRIPTION
this will handle packets headers that contain 4 addr properly, seen this usually in RouterOS wireless sniffed packets that contains QoS header, this is example packet :

> ```
> [
>   {
>     "_index": "packets-2018-06-18",
>     "_type": "pcap_file",
>     "_score": null,
>     "_source": {
>       "layers": {
>         "frame": {
>           "frame.encap_type": "20",
>           "frame.time": "Jun 17, 2018 17:42:27.669086000 EEST",
>           "frame.offset_shift": "0.000000000",
>           "frame.time_epoch": "1529246547.669086000",
>           "frame.time_delta": "0.002050000",
>           "frame.time_delta_displayed": "0.002057000",
>           "frame.time_relative": "6.843061000",
>           "frame.number": "8391",
>           "frame.len": "195",
>           "frame.cap_len": "195",
>           "frame.marked": "0",
>           "frame.ignored": "0",
>           "frame.protocols": "wlan:llc:eapol"
>         },
>         "wlan": {
>           "wlan.fc.type_subtype": "40",
>           "wlan.fc": "0x00008803",
>           "wlan.fc_tree": {
>             "wlan.fc.version": "0",
>             "wlan.fc.type": "2",
>             "wlan.fc.subtype": "8",
>             "wlan.flags": "0x00000003",
>             "wlan.flags_tree": {
>               "wlan.fc.ds": "0x00000003",
>               "wlan.fc.tods": "1",
>               "wlan.fc.fromds": "1",
>               "wlan.fc.frag": "0",
>               "wlan.fc.retry": "0",
>               "wlan.fc.pwrmgt": "0",
>               "wlan.fc.moredata": "0",
>               "wlan.fc.protected": "0",
>               "wlan.fc.order": "0"
>             }
>           },
>           "wlan.duration": "60",
>           "wlan.ra": "11:22:33:44:55:66",
>           "wlan.da": "11:22:33:44:55:66",
>           "wlan.ta": "aa:bb:cc:dd:ee:ff",
>           "wlan.sa": "aa:bb:cc:dd:ee:ff",
>           "wlan.bssid": "aa:bb:cc:dd:ee:ff",
>           "wlan.frag": "0",
>           "wlan.seq": "1",
>           "wlan.addr": "11:22:33:44:55:66",
>           "wlan.addr": "aa:bb:cc:dd:ee:ff",
>           "wlan.addr": "aa:bb:cc:dd:ee:ff",
>           "wlan.addr": "11:22:33:44:55:66",
>           "wlan.addr": "aa:bb:cc:dd:ee:ff",
>           "wlan.qos": "0x00000000",
>           "wlan.qos_tree": {
>             "wlan.qos.tid": "0",
>             "wlan.qos.priority": "0",
>             "wlan.qos.eosp": "0",
>             "wlan.qos.ack": "0x00000000",
>             "wlan.qos.amsdupresent": "0",
>             "wlan.qos.ps_buf_state": "0x00000000",
>             "wlan.qos.ps_buf_state_tree": {
>               "wlan.qos.buf_state_indicated": "0"
>             }
>           }
>         },
>         "llc": {
>           "llc.dsap": "0x000000aa",
>           "llc.dsap_tree": {
>             "llc.dsap.sap": "85",
>             "llc.dsap.ig": "0"
>           },
>           "llc.ssap": "0x000000aa",
>           "llc.ssap_tree": {
>             "llc.ssap.sap": "85",
>             "llc.ssap.cr": "0"
>           },
>           "llc.control": "0x00000003",
>           "llc.control_tree": {
>             "llc.control.u_modifier_cmd": "0x00000000",
>             "llc.control.ftype": "0x00000003"
>           },
>           "llc.oui": "0x00000000",
>           "llc.type": "0x0000888e"
>         },
>         "eapol": {
>           "eapol.version": "1",
>           "eapol.type": "3",
>           "eapol.len": "151",
>           "eapol.keydes.type": "2",
>           "wlan_rsna_eapol.keydes.key_info": "0x000013ca",
>           "wlan_rsna_eapol.keydes.key_info_tree": {
>             "wlan_rsna_eapol.keydes.key_info.keydes_version": "2",
>             "wlan_rsna_eapol.keydes.key_info.key_type": "1",
>             "wlan_rsna_eapol.keydes.key_info.key_index": "0",
>             "wlan_rsna_eapol.keydes.key_info.install": "1",
>             "wlan_rsna_eapol.keydes.key_info.key_ack": "1",
>             "wlan_rsna_eapol.keydes.key_info.key_mic": "1",
>             "wlan_rsna_eapol.keydes.key_info.secure": "1",
>             "wlan_rsna_eapol.keydes.key_info.error": "0",
>             "wlan_rsna_eapol.keydes.key_info.request": "0",
>             "wlan_rsna_eapol.keydes.key_info.encrypted_key_data": "1",
>             "wlan_rsna_eapol.keydes.key_info.smk_message": "0"
>           },
>           "eapol.keydes.key_len": "16",
>           "eapol.keydes.replay_counter": "2",
>           "wlan_rsna_eapol.keydes.nonce": "0e:d9:a5:bc:12:79:10:05:e2:76:27:88:6c:d6:6e:00:c5:5f:fb:ce:66:71:a0:d3:ef:be:5b:98:98:df:b6:89",
>           "eapol.keydes.key_iv": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
>           "wlan_rsna_eapol.keydes.rsc": "00:00:00:00:00:00:00:00",
>           "wlan_rsna_eapol.keydes.id": "00:00:00:00:00:00:00:00",
>           "wlan_rsna_eapol.keydes.mic": "97:b3:11:42:c7:4b:58:73:47:1c:aa:0a:22:a8:f9:a6",
>           "wlan_rsna_eapol.keydes.data_len": "56",
>           "wlan_rsna_eapol.keydes.data": "d2:36:f8:99:33:e1:ee:7e:5e:42:1a:3f:12:b7:ae:2c:ab:d2:30:18:a8:72:1b:32:d6:5b:3f:69:11:8d:6d:2f:22:e7:e0:bc:83:8b:5f:0b:b8:00:fa:b1:ea:1c:da:46:c2:88:11:63:00:60:4b:96"
>         }
>       }
>     }
>   }
> ]
> ```