### PR TITLE
Added combinatorX, version 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.bin
 *.exe
+*.dSYM
 bin/

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,6 +42,7 @@ release: native windows
 clean:
 	rm -f ../bin/*
 	rm -f *.bin *.exe
+	rm -rf *.dSYM
 
 ##
 ## native

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,33 @@
 ##  Makefile
 ##
 
-CFLAGS += -Wall -W -pipe -O2 -std=gnu99
+DEBUG                   := 0
+
+CFLAGS                  += -Wall -W -pipe -std=gnu99
+
+ifeq ($(DEBUG),0)
+CFLAGS                  += -O2
+ifneq ($(UNAME),Darwin)
+LFLAGS                  += -s
+endif
+else
+ifeq ($(DEBUG),1)
+ifneq ($(UNAME),Darwin)
+CFLAGS                  += -DDEBUG -Og -ggdb
+else
+CFLAGS                  += -DDEBUG -O0 -ggdb
+endif
+else
+ifeq ($(DEBUG),2)
+ifneq ($(UNAME),Darwin)
+CFLAGS                  += -DDEBUG -Og -ggdb
+else
+CFLAGS                  += -DDEBUG -O0 -ggdb
+endif
+CFLAGS                  += -fsanitize=address -fno-omit-frame-pointer
+endif
+endif
+endif
 
 all: clean native
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,6 +32,7 @@ native:
 	${CC_NATIVE} ${CFLAGS_NATIVE} ${LDFLAGS_NATIVE} -o cleanup-rules.bin cleanup-rules.c
 	${CC_NATIVE} ${CFLAGS_NATIVE} ${LDFLAGS_NATIVE} -o combinator.bin combinator.c
 	${CC_NATIVE} ${CFLAGS_NATIVE} ${LDFLAGS_NATIVE} -o combinator3.bin combinator3.c
+	${CC_NATIVE} ${CFLAGS_NATIVE} ${LDFLAGS_NATIVE} -o combinatorX.bin combinatorX.c
 	${CC_NATIVE} ${CFLAGS_NATIVE} ${LDFLAGS_NATIVE} -o combipow.bin combipow.c
 	${CC_NATIVE} ${CFLAGS_NATIVE} ${LDFLAGS_NATIVE} -o ct3_to_ntlm.bin ct3_to_ntlm.c
 	${CC_NATIVE} ${CFLAGS_NATIVE} ${LDFLAGS_NATIVE} -o cutb.bin cutb.c
@@ -70,6 +71,7 @@ windows:
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o cleanup-rules.exe cleanup-rules.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combinator.exe combinator.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combinator3.exe combinator3.c
+	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combinatorX.bin combinatorX.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combipow.exe combipow.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o ct3_to_ntlm.exe ct3_to_ntlm.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o cutb.exe cutb.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -98,7 +98,7 @@ windows:
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o cleanup-rules.exe cleanup-rules.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combinator.exe combinator.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combinator3.exe combinator3.c
-	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combinatorX.bin combinatorX.c
+	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combinatorX.exe combinatorX.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o combipow.exe combipow.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o ct3_to_ntlm.exe ct3_to_ntlm.c
 	${CC_WINDOWS} ${CFLAGS_WINDOWS} -o cutb.exe cutb.c

--- a/src/combinatorX.c
+++ b/src/combinatorX.c
@@ -1,0 +1,527 @@
+/**
+ * Name........: combinatorX
+ * Author......: Gabriele 'matrix' Gristina <gabriele.gristina@gmail.com>
+ * Version.....: 1.0
+ * License.....: MIT
+ *
+ * Enhanced version of jsteube 'combinator3'
+ * feat. lightweight dolphin macro :P
+ */
+
+#define _GNU_SOURCE
+#define _FILE_OFFSET_BITS 64
+#define __MSVCRT_VERSION__ 0x0700
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <unistd.h>
+
+#include "utils.c"
+
+#define LEN_MAX 32
+
+#define SEGMENT_SIZE  (32 * 1024 * 1024)
+#define SEGMENT_ALIGN ( 8 * 1024)
+
+// lightweight dolphin macro
+#define MEMORY_FREE_ADD(a)      { freeList[freeListIdx++] = (void *)(a); }
+#define MEMORY_FREE_ALL         { int t=freeListIdx; while (t-- > 0) if (freeList[t]!=NULL) { free (freeList[t]); freeList[t]=NULL; } if (freeList!=NULL) { free (freeList); freeList=NULL; } }
+
+static size_t read_segment (char *buf, FILE *fd)
+{
+  size_t read_sz = SEGMENT_SIZE - SEGMENT_ALIGN;
+  size_t real_sz = fread (buf, 1, read_sz, fd);
+
+  if (real_sz == 0) return (0);
+
+  if (real_sz != read_sz)
+  {
+    if (buf[real_sz - 1] != '\n')
+    {
+      real_sz++;
+
+      buf[real_sz - 1] = '\n';
+    }
+
+    return (real_sz);
+  }
+
+  size_t extra;
+
+  for (extra = 0; extra < SEGMENT_ALIGN; extra++)
+  {
+    if (fread (buf + real_sz, 1, 1, fd) == 0) break;
+
+    real_sz++;
+
+    if (buf[real_sz - 1] == '\n') break;
+  }
+
+  return (real_sz);
+}
+
+static size_t get_line_len (char *pos, char *max)
+{
+  char *cur = pos;
+
+  for (cur = pos; cur < max; cur++)
+  {
+    if (*cur == '\n') break;
+  }
+
+  size_t len = (size_t) (cur - pos);
+
+  return (len);
+}
+
+static void add (char *ptr_out,
+                 char *ptr_in1, size_t len_in1,
+                 char *ptr_in2, size_t len_in2,
+                 char *ptr_in3, size_t len_in3,
+                 char *ptr_in4, size_t len_in4,
+                 char *sepStart, size_t sepStart_len,
+                 char *sep1, size_t sep1_len,
+                 char *sep2, size_t sep2_len,
+                 char *sep3, size_t sep3_len,
+                 char *sepEnd, size_t sepEnd_len)
+{
+  if (sepStart_len != 0)
+  {
+    memcpy (ptr_out, sepStart, sepStart_len);
+    ptr_out += sepStart_len;
+  }
+
+  memcpy (ptr_out, ptr_in1, len_in1);
+  ptr_out += len_in1;
+
+  if (sep1_len != 0)
+  {
+    memcpy (ptr_out, sep1, sep1_len);
+    ptr_out += sep1_len;
+  }
+
+  memcpy (ptr_out, ptr_in2, len_in2);
+  ptr_out += len_in2;
+
+  if (sep2_len != 0)
+  {
+    memcpy (ptr_out, sep2, sep2_len);
+    ptr_out += sep2_len;
+  }
+
+  memcpy (ptr_out, ptr_in3, len_in3);
+  ptr_out += len_in3;
+
+  if (sep3_len != 0)
+  {
+    memcpy (ptr_out, sep3, sep3_len);
+    ptr_out += sep3_len;
+  }
+
+  memcpy (ptr_out, ptr_in4, len_in4);
+  ptr_out += len_in4;
+
+  if (sepEnd_len != 0)
+  {
+    memcpy (ptr_out, sepEnd, sepEnd_len);
+    ptr_out += sepEnd_len;
+  }
+
+  *ptr_out = '\n';
+}
+
+static struct option long_options[] =
+{
+  {"file1",    required_argument, NULL, 0xf1},
+  {"file2",    required_argument, NULL, 0xf2},
+  {"file3",    required_argument, NULL, 0xf3},
+  {"file4",    required_argument, NULL, 0xf4},
+  {"sepStart", required_argument, NULL, 0xa0},
+  {"sep1",     required_argument, NULL, 0xa1},
+  {"sep2",     required_argument, NULL, 0xa2},
+  {"sep3",     required_argument, NULL, 0xa3},
+  {"sepEnd",   required_argument, NULL, 0xaf},
+  {0, 0, 0, 0}
+};
+
+/**
+ * add to output buffer
+ */
+
+#define ADD_TO_OUTPUT_BUFFER(buf_out,ptr_out,ptr_in1,vir_in1,ptr_in2,vir_in2,ptr_in3,vir_in3,ptr_in4,vir_in4,sepStart,sepStart_len,sep1,sep1_len,sep2,sep2_len,sep3,sep3_len,sepEnd,sepEnd_len) \
+{ \
+  size_t len_out = (size_t) (ptr_out - buf_out); \
+  size_t len_add = sepStart_len + vir_in1 + sep1_len + vir_in2 + sep2_len + vir_in3 + sep3_len + vir_in4 + sepEnd_len + 1; \
+\
+  if ((len_out + len_add) < SEGMENT_SIZE) \
+  { \
+    add (ptr_out, ptr_in1, vir_in1, ptr_in2, vir_in2, ptr_in3, vir_in3, ptr_in4, vir_in4, sepStart, sepStart_len, sep1, sep1_len, sep2, sep2_len, sep3, sep3_len, sepEnd, sepEnd_len); \
+    ptr_out += len_add; \
+  } \
+  else \
+  { \
+    fwrite (buf_out, 1, len_out, stdout); \
+    ptr_out = buf_out; \
+    add (ptr_out, ptr_in1, vir_in1, ptr_in2, vir_in2, ptr_in3, vir_in3, ptr_in4, vir_in4, sepStart, sepStart_len, sep1, sep1_len, sep2, sep2_len, sep3, sep3_len, sepEnd, sepEnd_len); \
+    ptr_out += len_add; \
+  } \
+}
+
+static void usage (char *p)
+{
+  fprintf (stdout,
+    "Usage: %s [<options>]\n\n" \
+    "Options:\n\n" \
+    "  Argument   | Type        | Description                           | Option type | Example\n" \
+    "  ----------------------------------------------------------------------------------------------\n"
+    "  --file1    | Path        | Set file1 path                        | required    | --file1 wordlist1.txt\n" \
+    "  --file2    | Path        | Set file2 path                        | required    | --file2 wordlist2.txt\n" \
+    "  --file3    | Path        | Set file3 path                        | optional    | --file3 wordlist3.txt\n" \
+    "  --file4    | Path        | Set file4 path                        | optional    | --file4 wordlist4.txt\n" \
+    "\n" \
+    "  --sepStart | Char/String | Set char/string at the beginning      | optional    | --sepStart '['\n" \
+    "  --sep1     | Char/String | Set separator between file1 and file2 | optional    | --sep1 'a.'\n" \
+    "  --sep2     | Char/String | Set separator between file2 and file3 | optional    | --sep2 'bc'\n" \
+    "  --sep3     | Char/String | Set separator between file3 and file4 | optional    | --sep3 ',d'\n" \
+    "  --sepEnd   | Char/String | Set char/string at the end            | optional    | --sepEnd ']'\n" \
+    "\n\n" \
+    "Example:\n\n" \
+    "input files: 1 2 3 4\n" \
+    "$ cat 1 2 3 4 | xargs\n" \
+    "one two three four\n" \
+    "$ ./combinatorX.bin --file1 1 --file2 2 --file3 3 --file4 4 --sep1 ' . ' --sep2 ' + ' --sep3 ' @ ' --sepStart \"['\" --sepEnd ',*]'\n"
+    "['one . two + three @ four,*]\n\n", p);
+}
+
+int main (int argc, char *argv[])
+{
+  int opt = 0;
+  int long_index = 0;
+  int err = 0;
+
+  char **freeList = malloc(15 * sizeof(char *));
+  int freeListIdx = 0;
+
+  char *f1 = NULL, *f2 = NULL, *f3 = NULL, *f4 = NULL;
+  char *sepStart = NULL, *sep1 = NULL, *sep2 = NULL, *sep3 = NULL, *sepEnd = NULL;
+  size_t sepStart_len = 0, sep1_len = 0, sep2_len = 0, sep3_len = 0, sepEnd_len = 0;
+
+  while ((opt = getopt_long_only (argc, argv,"", long_options, &long_index )) != -1)
+  {
+    switch (opt)
+    {
+      case 0xa0:
+        sepStart_len = strlen(optarg);
+        sepStart = strdup(optarg);
+
+        MEMORY_FREE_ADD(sepStart)
+        break;
+
+      case 0xa1:
+        sep1_len = strlen(optarg);
+        sep1 = strdup(optarg);
+
+        MEMORY_FREE_ADD(sep1)
+        break;
+
+      case 0xa2:
+        sep2_len = strlen(optarg);
+        sep2 = strdup(optarg);
+
+        MEMORY_FREE_ADD(sep2)
+        break;
+
+      case 0xa3:
+        sep3_len = strlen(optarg);
+        sep3 = strdup(optarg);
+
+        MEMORY_FREE_ADD(sep3)
+        break;
+
+      case 0xaf:
+        sepEnd_len = strlen(optarg);
+        sepEnd = strdup(optarg);
+
+        MEMORY_FREE_ADD(sepEnd)
+        break;
+
+      case 0xf1:
+        if (strlen (optarg) > 0 && access (optarg, F_OK) == 0) { f1 = strdup (optarg); MEMORY_FREE_ADD(f1) }
+        else err++;
+        break;
+
+      case 0xf2:
+        if (strlen (optarg) > 0 && access (optarg, F_OK) == 0) { f2 = strdup (optarg); MEMORY_FREE_ADD(f2) }
+        else err++;
+        break;
+
+      case 0xf3:
+        if (strlen (optarg) > 0 && access (optarg, F_OK) == 0) { f3 = strdup (optarg); MEMORY_FREE_ADD(f3) }
+        else err++;
+        break;
+
+      case 0xf4:
+        if (strlen (optarg) > 0 && access (optarg, F_OK) == 0) { f4 = strdup (optarg); MEMORY_FREE_ADD(f4) }
+        else err++;
+        break;
+
+      default:
+        err++;
+        break;
+    }
+  }
+
+  if (err > 0)
+  {
+    fprintf (stderr, "! Invalid arguments ...\n");
+    usage (argv[0]);
+
+    MEMORY_FREE_ALL
+
+    return -1;
+  }
+
+  if (f1 == NULL || f2 == NULL)
+  {
+    fprintf (stderr, "! file1 and/or file2 are not set ...\n");
+    usage (argv[0]);
+
+    MEMORY_FREE_ALL
+
+    return -1;
+  }
+
+  if (f3 == NULL)
+  {
+    if (sep3)
+    {
+      fprintf (stderr, "! Cannot set --sep3 if file3 is not set ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+
+    if (f4)
+    {
+      fprintf (stderr, "! Cannot set --file4 if file3 is not set ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+  }
+
+  size_t sz_buf = SEGMENT_SIZE + SEGMENT_ALIGN;
+
+  char *buf_in1 = (char *) malloc (sz_buf);
+  char *buf_in2 = (char *) malloc (sz_buf);
+  char *buf_in3 = NULL;
+  char *buf_in4 = NULL;
+
+  MEMORY_FREE_ADD (buf_in1)
+  MEMORY_FREE_ADD (buf_in2)
+
+  if (f3 != NULL)
+  {
+    buf_in3 = (char *) malloc (sz_buf);
+
+    MEMORY_FREE_ADD (buf_in3)
+  }
+  if (f4 != NULL)
+  {
+    buf_in4 = (char *) malloc (sz_buf);
+
+    MEMORY_FREE_ADD (buf_in4)
+  }
+
+  char *buf_out = (char *) malloc (sz_buf);
+
+  MEMORY_FREE_ADD (buf_out)
+
+  char *ptr_out = buf_out;
+
+  FILE *fd1 = NULL;
+  FILE *fd2 = NULL;
+  FILE *fd3 = NULL;
+  FILE *fd4 = NULL;
+
+  if ((fd1 = fopen (f1, "rb")) == NULL)
+  {
+    fprintf (stderr, "%s: %s\n", f1, strerror (errno));
+
+    MEMORY_FREE_ALL
+
+    return (-1);
+  }
+
+  if ((fd2 = fopen (f2, "rb")) == NULL)
+  {
+    fprintf (stderr, "%s: %s\n", f2, strerror (errno));
+
+    fclose (fd1);
+
+    MEMORY_FREE_ALL
+
+    return (-1);
+  }
+
+  if (f3 && (fd3 = fopen (f3, "rb")) == NULL)
+  {
+    fprintf (stderr, "%s: %s\n", f3, strerror (errno));
+
+    fclose (fd1);
+    fclose (fd2);
+
+    MEMORY_FREE_ALL
+
+    return (-1);
+  }
+
+  if (f4 && (fd4 = fopen (f4, "rb")) == NULL)
+  {
+    fprintf (stderr, "%s: %s\n", f4, strerror (errno));
+
+    fclose (fd1);
+    fclose (fd2);
+    fclose (fd3);
+
+    MEMORY_FREE_ALL
+
+    return (-1);
+  }
+
+  char *ptr_in1 = NULL;
+  char *ptr_in2 = NULL;
+  char *ptr_in3 = NULL;
+  char *ptr_in4 = NULL;
+
+  size_t vir_in1 = 0;
+  size_t vir_in2 = 0;
+  size_t vir_in3 = 0;
+  size_t vir_in4 = 0;
+
+  while (!feof (fd1))
+  {
+    size_t real_sz1 = read_segment (buf_in1, fd1);
+    size_t len_in1 = 0;
+    char *max_in1 = buf_in1 + real_sz1;
+
+    for (ptr_in1 = buf_in1; ptr_in1 < max_in1; ptr_in1 += len_in1 + 1)
+    {
+      len_in1 = get_line_len (ptr_in1, max_in1);
+      vir_in1 = len_in1;
+
+      while (vir_in1)
+      {
+        if (ptr_in1[vir_in1 - 1] != '\r') break;
+        vir_in1--;
+      }
+
+      if (vir_in1 > LEN_MAX) continue;
+
+      while (!feof (fd2))
+      {
+        size_t real_sz2 = read_segment (buf_in2, fd2);
+        size_t len_in2 = 0;
+        char *max_in2 = buf_in2 + real_sz2;
+
+        for (ptr_in2 = buf_in2; ptr_in2 < max_in2; ptr_in2 += len_in2 + 1)
+        {
+          len_in2 = get_line_len (ptr_in2, max_in2);
+          vir_in2 = len_in2;
+
+          while (vir_in2)
+          {
+            if (ptr_in2[vir_in2 - 1] != '\r') break;
+            vir_in2--;
+          }
+
+          if (vir_in2 > LEN_MAX) continue;
+
+          if (buf_in3)
+          {
+            while (!feof (fd3))
+            {
+              size_t real_sz3 = read_segment (buf_in3, fd3);
+              size_t len_in3 = 0;
+              char *max_in3 = buf_in3 + real_sz3;
+
+              for (ptr_in3 = buf_in3; ptr_in3 < max_in3; ptr_in3 += len_in3 + 1)
+              {
+                len_in3 = get_line_len (ptr_in3, max_in3);
+                vir_in3 = len_in3;
+
+                while (vir_in3)
+                {
+                  if (ptr_in3[vir_in3 - 1] != '\r') break;
+                  vir_in3--;
+                }
+
+                if (vir_in3 > LEN_MAX) continue;
+
+                if (buf_in4)
+                {
+                  while (!feof (fd4))
+                  {
+                    size_t real_sz4 = read_segment (buf_in4, fd4);
+                    size_t len_in4 = 0;
+                    char *max_in4 = buf_in4 + real_sz4;
+
+                    for (ptr_in4 = buf_in4; ptr_in4 < max_in4; ptr_in4 += len_in4 + 1)
+                    {
+                      len_in4 = get_line_len (ptr_in4, max_in4);
+                      vir_in4 = len_in4;
+
+                      while (vir_in4)
+                      {
+                        if (ptr_in4[vir_in4 - 1] != '\r') break;
+                        vir_in4--;
+                      }
+
+                      if (vir_in4 > LEN_MAX) continue;
+
+                      ADD_TO_OUTPUT_BUFFER(buf_out, ptr_out, ptr_in1, vir_in1, ptr_in2, vir_in2, ptr_in3, vir_in3, ptr_in4, vir_in4, sepStart, sepStart_len, sep1, sep1_len, sep2, sep2_len, sep3, sep3_len, sepEnd, sepEnd_len)
+                    }
+                  }
+                  rewind (fd4);
+                }
+                else
+                {
+                  ADD_TO_OUTPUT_BUFFER(buf_out, ptr_out, ptr_in1, vir_in1, ptr_in2, vir_in2, ptr_in3, vir_in3, ptr_in4, vir_in4, sepStart, sepStart_len, sep1, sep1_len, sep2, sep2_len, sep3, sep3_len, sepEnd, sepEnd_len)
+                }
+              }
+            }
+            rewind (fd3);
+          }
+          else
+          {
+            ADD_TO_OUTPUT_BUFFER(buf_out, ptr_out, ptr_in1, vir_in1, ptr_in2, vir_in2, ptr_in3, vir_in3, ptr_in4, vir_in4, sepStart, sepStart_len, sep1, sep1_len, sep2, sep2_len, sep3, sep3_len, sepEnd, sepEnd_len)
+          }
+        }
+      }
+      rewind (fd2);
+    }
+  }
+
+  size_t len_out = (size_t) (ptr_out - buf_out);
+
+  fwrite (buf_out, 1, len_out, stdout);
+
+  if (fd4) fclose (fd4);
+  if (fd3) fclose (fd3);
+  fclose (fd2);
+  fclose (fd1);
+
+  MEMORY_FREE_ALL
+
+  return 0;
+}

--- a/src/combinatorX.c
+++ b/src/combinatorX.c
@@ -1,7 +1,7 @@
 /**
  * Name........: combinatorX
  * Author......: Gabriele 'matrix' Gristina <gabriele.gristina@gmail.com>
- * Version.....: 1.0
+ * Version.....: 1.1
  * License.....: MIT
  *
  * Enhanced version of jsteube 'combinator3'
@@ -29,7 +29,7 @@
 #define LEN_MAX 64
 
 #define SEGMENT_SIZE  (LEN_MAX * 1024 * 1024)
-#define SEGMENT_ALIGN ( 8 * 1024)
+#define SEGMENT_ALIGN (8 * 1024)
 
 // lightweight dolphin macro
 #define MEMORY_FREE_ADD(a) { freeList[freeListIdx++] = (void *)(a); }
@@ -89,9 +89,9 @@ bool session_init (bool restore, long *off_fd1, long *off_fd2, long *off_fd3, lo
 }
 
 /*
-void session_print (long off_fd1, long off_fd2, long off_fd3, long off_fd4, size_t off_vir_in1, size_t off_vir_in2, size_t off_vir_in3, size_t off_vir_in4)
+void session_print (long off_fd1, long off_fd2, long off_fd3, long off_fd4, long off_fd5, size_t off_vir_in1, size_t off_vir_in2, size_t off_vir_in3, size_t off_vir_in4, size_t off_vir_in5)
 {
-  printf ("Session data: %ld,%ld,%ld,%ld,%zu,%zu,%zu,%zu\n", off_fd1, off_fd2, off_fd3, off_fd4, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4);
+  printf ("Session data: %ld,%ld,%ld,%ld,%ld,%zu,%zu,%zu,%zu,%zu\n", off_fd1, off_fd2, off_fd3, off_fd4, off_fd5, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4, off_vir_in5);
   fflush (stdout);
 }
 */
@@ -342,7 +342,7 @@ static void usage (char *p)
     "  --sep1     | Char/String | Set separator between file1 and file2 | optional    | --sep1 'a.'\n" \
     "  --sep2     | Char/String | Set separator between file2 and file3 | optional    | --sep2 'bc'\n" \
     "  --sep3     | Char/String | Set separator between file3 and file4 | optional    | --sep3 ',d'\n" \
-    "  --sep4     | Char/String | Set separator between file4 and file4 | optional    | --sep4 ',d'\n" \
+    "  --sep4     | Char/String | Set separator between file4 and file5 | optional    | --sep4 'e.'\n" \
     "  --sepEnd   | Char/String | Set char/string at the end            | optional    | --sepEnd ']'\n" \
     "\n" \
     "  --skip     | Num         | Skip N segments                       | optional    | --skip 0\n" \
@@ -367,7 +367,7 @@ int main (int argc, char *argv[])
   int err = 0;
   int set = 0;
 
-  char **freeList = malloc(15 * sizeof(char *));
+  char **freeList = malloc (17 * sizeof(char *));
   int freeListIdx = 0;
 
   char *f1 = NULL, *f2 = NULL, *f3 = NULL, *f4 = NULL, *f5 = NULL;
@@ -547,6 +547,115 @@ int main (int argc, char *argv[])
     }
   }
 
+  if (!strcmp (f1, f2))
+  {
+    fprintf (stderr, "! Cannot use the same file as input (f1 vs f2) ...\n");
+    usage(argv[0]);
+
+    MEMORY_FREE_ALL
+
+    return -1;
+  }
+
+  if (f3 != NULL)
+  {
+    if (!strcmp (f1, f3))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f1 vs f3) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+
+    if (!strcmp (f2, f3))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f2 vs f3) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+  }
+
+  if (f4 != NULL)
+  {
+    if (!strcmp (f1, f4))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f1 vs f4) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+
+    if (!strcmp (f2, f4))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f2 vs f4) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+
+    if (!strcmp (f3, f4))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f3 vs f4) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+  }
+
+  if (f5 != NULL)
+  {
+    if (!strcmp (f1, f5))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f1 vs f5) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+
+    if (!strcmp (f2, f5))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f2 vs f5) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+
+    if (!strcmp (f3, f5))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f3 vs f5) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+
+    if (!strcmp (f4, f5))
+    {
+      fprintf (stderr, "! Cannot use the same file as input (f4 vs f5) ...\n");
+      usage(argv[0]);
+
+      MEMORY_FREE_ALL
+
+      return -1;
+    }
+  }
+
   if (session_isSet && restore_isSet)
   {
     fprintf (stderr, "! Cannot use --session and --restore together ...\n");
@@ -693,7 +802,7 @@ int main (int argc, char *argv[])
   {
     session_init (restore_isSet, &off_fd1, &off_fd2, &off_fd3, &off_fd4, &off_fd5, &off_vir_in1, &off_vir_in2, &off_vir_in3, &off_vir_in4, &off_vir_in5);
 
-    //session_print (off_fd1, off_fd2, off_fd3, off_fd4, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4);
+    //session_print (off_fd1, off_fd2, off_fd3, off_fd4, off_fd5, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4, off_vir_in5);
 
     if (restore_isSet)
     {

--- a/src/combinatorX.c
+++ b/src/combinatorX.c
@@ -47,7 +47,7 @@ void sigHandler (int sig)
   end = true;
 }
 
-bool session_init (bool restore, long *off_fd1, long *off_fd2, long *off_fd3, long *off_fd4, long *off_fd5, unsigned long long *off_vir_in1, unsigned long long *off_vir_in2, unsigned long long *off_vir_in3, unsigned long long *off_vir_in4, unsigned long long *off_vir_in5)
+bool session_init (bool restore, int64_t *off_fd1, int64_t *off_fd2, int64_t *off_fd3, int64_t *off_fd4, int64_t *off_fd5, int64_t *off_vir_in1, int64_t *off_vir_in2, int64_t *off_vir_in3, int64_t *off_vir_in4, int64_t *off_vir_in5)
 {
   char *mode = (restore) ? "r+" : "w+";
 
@@ -75,7 +75,7 @@ bool session_init (bool restore, long *off_fd1, long *off_fd2, long *off_fd3, lo
     *off_vir_in5 = 0;
 
     // write status
-    fprintf (sfp, "%ld %ld %ld %ld %ld %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 "", *off_fd1, *off_fd2, *off_fd3, *off_fd4, *off_fd5, *off_vir_in1, *off_vir_in2, *off_vir_in3, *off_vir_in4, *off_vir_in5);
+    fprintf (sfp, "%" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 "", *off_fd1, *off_fd2, *off_fd3, *off_fd4, *off_fd5, *off_vir_in1, *off_vir_in2, *off_vir_in3, *off_vir_in4, *off_vir_in5);
     fflush (sfp);
 
     if (ftruncate (fileno (sfp), ftell (sfp)) != 0)
@@ -90,7 +90,7 @@ bool session_init (bool restore, long *off_fd1, long *off_fd2, long *off_fd3, lo
   }
 
   // restore session
-  if (fscanf (sfp, "%ld %ld %ld %ld %ld %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 "", off_fd1, off_fd2, off_fd3, off_fd4, off_fd5, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4, off_vir_in5) != 10)
+  if (fscanf (sfp, "%" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 "", off_fd1, off_fd2, off_fd3, off_fd4, off_fd5, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4, off_vir_in5) != 10)
   {
     fprintf (stderr, "! fscanf() failed\n");
     fclose (sfp);
@@ -104,15 +104,15 @@ bool session_init (bool restore, long *off_fd1, long *off_fd2, long *off_fd3, lo
 /*
 void session_print (long off_fd1, long off_fd2, long off_fd3, long off_fd4, long off_fd5, size_t off_vir_in1, size_t off_vir_in2, size_t off_vir_in3, size_t off_vir_in4, size_t off_vir_in5)
 {
-  printf ("Session data: %ld,%ld,%ld,%ld,%ld,%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "\n", off_fd1, off_fd2, off_fd3, off_fd4, off_fd5, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4, off_vir_in5);
+  printf ("Session data: %" PRIi64 ",%" PRIi64 ",%" PRIi64 ",%" PRIi64 ",%" PRIi64 ",%" PRIi64 ",%" PRIi64 ",%" PRIi64 ",%" PRIi64 ",%" PRIi64 "\n", off_fd1, off_fd2, off_fd3, off_fd4, off_fd5, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4, off_vir_in5);
   fflush (stdout);
 }
 */
 
-bool session_update (long off_fd1, long off_fd2, long off_fd3, long off_fd4, long off_fd5, unsigned long long off_vir_in1, unsigned long long off_vir_in2, unsigned long long off_vir_in3, unsigned long long off_vir_in4, unsigned long long off_vir_in5)
+bool session_update (int64_t off_fd1, int64_t off_fd2, int64_t off_fd3, int64_t off_fd4, int64_t off_fd5, int64_t off_vir_in1, int64_t off_vir_in2, int64_t off_vir_in3, int64_t off_vir_in4, int64_t off_vir_in5)
 {
   rewind (sfp);
-  fprintf (sfp, "%ld %ld %ld %ld %ld %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 "", off_fd1, off_fd2, off_fd3, off_fd4, off_fd5, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4, off_vir_in5);
+  fprintf (sfp, "%" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 " %" PRIi64 "", off_fd1, off_fd2, off_fd3, off_fd4, off_fd5, off_vir_in1, off_vir_in2, off_vir_in3, off_vir_in4, off_vir_in5);
   fflush (sfp);
 
   if (ftruncate (fileno (sfp), ftell (sfp)) != 0)
@@ -833,17 +833,17 @@ int main (int argc, char *argv[])
   size_t vir_in5 = 0;
 
   // session/restore
-  long off_fd1 = 0;
-  long off_fd2 = 0;
-  long off_fd3 = 0;
-  long off_fd4 = 0;
-  long off_fd5 = 0;
+  int64_t off_fd1 = 0;
+  int64_t off_fd2 = 0;
+  int64_t off_fd3 = 0;
+  int64_t off_fd4 = 0;
+  int64_t off_fd5 = 0;
 
-  unsigned long long off_vir_in1 = 0, off_vir_in1_init = -1;
-  unsigned long long off_vir_in2 = 0, off_vir_in2_init = -1;
-  unsigned long long off_vir_in3 = 0, off_vir_in3_init = -1;
-  unsigned long long off_vir_in4 = 0, off_vir_in4_init = -1;
-  unsigned long long off_vir_in5 = 0, off_vir_in5_init = -1;
+  int64_t off_vir_in1 = 0, off_vir_in1_init = -1;
+  int64_t off_vir_in2 = 0, off_vir_in2_init = -1;
+  int64_t off_vir_in3 = 0, off_vir_in3_init = -1;
+  int64_t off_vir_in4 = 0, off_vir_in4_init = -1;
+  int64_t off_vir_in5 = 0, off_vir_in5_init = -1;
 
   if (session_isSet || restore_isSet)
   {


### PR DESCRIPTION
Hi Jens,

i modified your combinator3, creating an improved version which I called "combinatorX".
Following the help with an example.

```
Usage: ./combinatorX.bin [<options>]

Options:

  Argument   | Type        | Description                           | Option type | Example
  ----------------------------------------------------------------------------------------------
  --file1    | Path        | Set file1 path                        | required    | --file1 wordlist1.txt
  --file2    | Path        | Set file2 path                        | required    | --file2 wordlist2.txt
  --file3    | Path        | Set file3 path                        | optional    | --file3 wordlist3.txt
  --file4    | Path        | Set file4 path                        | optional    | --file4 wordlist4.txt

  --sepStart | Char/String | Set char/string at the beginning      | optional    | --sepStart '['
  --sep1     | Char/String | Set separator between file1 and file2 | optional    | --sep1 'a.'
  --sep2     | Char/String | Set separator between file2 and file3 | optional    | --sep2 'bc'
  --sep3     | Char/String | Set separator between file3 and file4 | optional    | --sep3 ',d'
  --sepEnd   | Char/String | Set char/string at the end            | optional    | --sepEnd ']'


Example:

input files: 1 2 3 4
$ cat 1 2 3 4 | xargs
one two three four
$ ./combinatorX.bin --file1 1 --file2 2 --file3 3 --file4 4 --sep1 ' . ' --sep2 ' + ' --sep3 ' @ ' --sepStart "['" --sepEnd ',*]'
['one . two + three @ four,*]
```

See you soon,
Gabriele