### PR TITLE
Include pcap header linktype in error

### DIFF
--- a/src/cap2hccapx.c
+++ b/src/cap2hccapx.c
@@ -975,7 +975,7 @@ int main (int argc, char *argv[])
    && (pcap_file_header.linktype != DLT_IEEE802_11_RADIO)
    && (pcap_file_header.linktype != DLT_IEEE802_11_PPI_HDR))
   {
-    fprintf (stderr, "%s: Unsupported linktype detected\n", in);
+    fprintf (stderr, "%s: Unsupported linktype detected %d\n", in, pcap_file_header.linktype);
 
     return -1;
   }


### PR DESCRIPTION
I updated the error message displayed when the PCAP header has an unsupported link type.

Previously it would print something like:
```
./test2.pcap: Unsupported linktype detected
```

Now it prints something like
```
./test2.pcap: Unsupported linktype detected 113
```

This makes it easier to troubleshoot.