### PR TITLE
Fixed bug in generating random rule in src/cpu_rules.c

### DIFF
--- a/src/cpu_rules.c
+++ b/src/cpu_rules.c
@@ -577,7 +577,7 @@ int generate_random_rule (char rule_buf[RP_RULE_BUFSIZ], uint32_t rp_gen_func_mi
         p1 = get_random_num (0, sizeof (grp_pos));
         rule_buf[rule_pos++] = grp_pos[p1];
         p2 = get_random_num (1, sizeof (grp_pos));
-        rule_buf[rule_pos++] = grp_pos[p1];
+        rule_buf[rule_pos++] = grp_pos[p2];
         p3 = get_random_num (0, sizeof (grp_pos));
         rule_buf[rule_pos++] = grp_pos[p3];
         break;


### PR DESCRIPTION
I found a bug in function generate_random_rule() in script src/cpu_rules.c. The problem occurs when rule _RULE_OP_MANGLE_EXTRACT_MEMORY_ (written as '**X**') is generated. This rule function inserts substring of length M starting from position N of word saved to memory at position I (for example _X243_). Here are exactly described 3 operands (_XNMI_):

1. N -> starting position to extract from memory
2. M -> length of substring which will be extracted from memory
3. I -> position in password to insert extracted substring to

The problem occured when generating second operand (M). There is a random number _p2_ generated (minimal should be number 1), and **instead of using variable _p2_ when indexing array, there is used variable _p1_** (which results in potentially generating number 0).

Can be seen here:
```
        p2 = get_random_num (1, sizeof (grp_pos));
        rule_buf[rule_pos++] = grp_pos[p1];
```

I found this bug, because I used function _apply_rule_cpu()_ for validating created rules, and when randomly generated rule with the above described function was created, it was not always valid, because in second operand it expected number >= 1.
